### PR TITLE
Add missing device type: Automobile

### DIFF
--- a/src/spotifyaio/models.py
+++ b/src/spotifyaio/models.py
@@ -15,6 +15,7 @@ from mashumaro.types import Discriminator  # noqa: TCH002
 class DeviceType(StrEnum):
     """Device type."""
 
+    AUTOMOBILE = "Automobile"
     COMPUTER = "Computer"
     SMARTPHONE = "Smartphone"
     SPEAKER = "Speaker"


### PR DESCRIPTION
# Proposed Changes

```
mashumaro.exceptions.InvalidFieldValue: Field "devices" of type list[Device] in Devices has invalid value [{'id': 'XXXX', 'is_active': False, 'is_private_session': False, 'is_restricted': False, 'name': 'BMW iX', 'supports_volume': False, 'type': 'Automobile', 'volume_percent': 50}]
```