### PR TITLE
Update models.py - Add Device Type STB

### DIFF
--- a/src/spotifyaio/models.py
+++ b/src/spotifyaio/models.py
@@ -24,6 +24,7 @@ class DeviceType(StrEnum):
     SMARTPHONE = "Smartphone"
     SMARTWATCH = "Smartwatch"
     SPEAKER = "Speaker"
+    STB = "Set-Top Box"
     TABLET = "Tablet"
     TV = "TV"
 


### PR DESCRIPTION
# Proposed Changes

> Add Device type STB (Set-Top Box).

## Related Issues

> Issue in HA Spotify integration showing  



 File "<string>", line 24, in __mashumaro_from_dict_json__
  File "/usr/local/lib/python3.12/enum.py", line 757, in __call__
    return cls.__new__(cls, value)
           ^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/enum.py", line 1171, in __new__
    raise ve_exc
ValueError: 'STB' is not a valid DeviceType


See similar issue : https://github.com/home-assistant/core/issues/129704
