### PR TITLE
Update models.py - Add Set-Top Box STB

### DIFF
--- a/src/spotifyaio/models.py
+++ b/src/spotifyaio/models.py
@@ -21,6 +21,7 @@ class DeviceType(StrEnum):
     CAST_AUDIO = "CastAudio"
     CAST_VIDEO = "CastVideo"
     COMPUTER = "Computer"
+    SET-TOP_BOX = "STB"
     SMARTPHONE = "Smartphone"
     SMARTWATCH = "Smartwatch"
     SPEAKER = "Speaker"

--- a/src/spotifyaio/models.py
+++ b/src/spotifyaio/models.py
@@ -21,7 +21,7 @@ class DeviceType(StrEnum):
     CAST_AUDIO = "CastAudio"
     CAST_VIDEO = "CastVideo"
     COMPUTER = "Computer"
-    SET-TOP_BOX = "STB"
+    SET_TOP_BOX = "STB"
     SMARTPHONE = "Smartphone"
     SMARTWATCH = "Smartwatch"
     SPEAKER = "Speaker"


### PR DESCRIPTION
# Proposed Changes

> Add Device type STB (Set-Top Box).

## Related Issues

> Issue in HA Spotify integration showing  



 File "<string>", line 24, in __mashumaro_from_dict_json__
  File "/usr/local/lib/python3.12/enum.py", line 757, in __call__
    return cls.__new__(cls, value)
           ^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/enum.py", line 1171, in __new__
    raise ve_exc
ValueError: 'STB' is not a valid DeviceType


See similar issue : https://github.com/home-assistant/core/issues/129704
