### PR TITLE
bugfix: handle missing items in Playlist and PlaylistTracks

### DIFF
--- a/src/spotifyaio/models.py
+++ b/src/spotifyaio/models.py
@@ -421,7 +421,7 @@ class BasePlaylist(DataClassORJSONMixin):
 class Playlist(BasePlaylist):
     """Playlist model."""
 
-    items: PlaylistTracks
+    items: PlaylistTracks | None = None
 
     @classmethod
     def __pre_deserialize__(cls, d: dict[str, Any]) -> dict[str, Any]:
@@ -440,8 +440,8 @@ class PlaylistTracks(DataClassORJSONMixin):
     @classmethod
     def __pre_deserialize__(cls, d: dict[str, Any]) -> dict[str, Any]:
         """Pre deserialize hook."""
-        items = [item for item in d["items"] if not item["is_local"]]
-        return {"items": items}
+	items = [item for item in (d.get("items") or []) if not item.get("is_local", False)]        
+	return {"items": items}
 
 
 @dataclass


### PR DESCRIPTION
Problem: 
Spotify API returns simplified playlist objects (e.g. in user playlist lists) where tracks contains only href and total without items. 

This causes KeyError/deserialization failure: 
Field "items" of type PlaylistTracks is missing in Playlist instance.                                                                                                                                            
                                                                                                                                                                                                             
Fix:                                                    
- Make Playlist.items optional (None default)
- Use d.get("items") or [] in PlaylistTracks.__pre_deserialize__ to handle missing field gracefully
