### PR TITLE
fix: pass uri and device_id as query params in add_to_queue

### DIFF
--- a/src/spotifyaio/spotify.py
+++ b/src/spotifyaio/spotify.py
@@ -434,7 +434,7 @@ class SpotifyClient:
         data: dict[str, str] = {"uri": uri}
         if device_id:
             data["device_id"] = device_id
-        await self._post("v1/me/player/queue", data=data)
+        await self._post("v1/me/player/queue", params=data)
 
     @catch_json_decode_error
     async def get_playlist(self, playlist_id: str) -> Playlist:


### PR DESCRIPTION
# Proposed Changes

Even if it's tiny, here is a PR for using query parameters instead of the request body for data. 
Details are in the linked issue.

## Related Issues

fixes #772 
